### PR TITLE
Update instructions and code of conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Maliciously attributing the wrong owner or repository in the URL of a package entry contributed to <https://github.com/r-releases/r-releases/tree/main/packages>.
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at will.landau.oss@gmail.com. 
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # r-releases
 
-`r-releases` is a community-curated [R universe](https://r-releases.r-universe.dev) of R packages deployed as tags/releases on GitHub. The GitHub repository at <https://github.com/r-releases/r-releases> allows anyone to register packages  with the [universe](https://r-releases.r-universe.dev). The project is still in its prototype phase, but the goal is to build a production-ready community-wide CRAN-like repository that incentivizes thorough testing and puts control in the hands of the package maintainers.
+`r-releases` is a community-curated [R universe](https://r-releases.r-universe.dev) of R packages deployed as tags/releases on GitHub. The GitHub repository at <https://github.com/r-releases/r-releases> allows anyone to register packages with the [universe](https://r-releases.r-universe.dev). The project is still in its prototype phase, but the goal is to build a production-ready community-wide CRAN-like repository that incentivizes thorough testing and puts control in the hands of the package maintainers.
+
+# Disclaimer
+
+The `r-releases` project is brand new and in its prototype phase. It is not ready for widespread production usage, and policies are subject to change.
 
 # How to install a package from `r-releases`
 
@@ -10,31 +14,56 @@ To install a package from `r-releases` (for example, `jsonlite`), open R and run
 install.packages("jsonlite", repos = "https://r-releases.r-universe.dev")
 ```
 
-# Disclaimer
+If the package has dependencies in CRAN but not `r-releases`, please contribute them to `r-releases` as described below. As a temporary workaround for installation, you can include CRAN as a backup:
 
-The `r-releases` project is brand new and in its prototype phase. It is not ready for widespread production usage, and policies are subject to change.
+```r
+install.packages(
+  "jsonlite",
+  repos = c("https://r-releases.r-universe.dev", "https://cloud.r-project.org")
+)
+```
 
-# How to add your package
+# Before you contribute
 
-To add your package to `r-releases`, first put your package in a GitHub or GitLab repository. Then, open a [GitHub pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to <https://github.com/r-releases/r-releases.r-universe.dev> to add one or more text files to the [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages) of <https://github.com/r-releases/r-releases>. The name of each file should be the package name, and the only contents of the file should be the URL of the package. Please ensure all your text files [end with a newline](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline). See the [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages) folder for examples.
+The [code of conduct](https://github.com/r-releases/help/blob/main/CODE_OF_CONDUCT.md) governs all forms of participation in the `r-releases` project, including package contributions, issues, discussions, and the development of infrastructure. Both administrators and contributors are subject to its terms.
+
+# How to add your package to `r-releases`
+
+To contribute your package to `r-releases`:
+
+1. Put the source code of your R package in a public [GitHub](https://github.com) (or [GitLab](https://gitlab.com)) repository with the `DESCRIPTION` file at the root of the project. Example: <https://github.com/r-lib/gh>.
+2. Create a [tag and release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for the latest production version of your package. Example: <https://github.com/r-lib/gh/releases/tag/v1.4.0>.
+3. Open a [GitHub pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to <https://github.com/r-releases/r-releases> to contribute a text file to the [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages). The name of the text file must be the name of your package, and the URL must include the correct owner and the correct repository.
+
+In the overwhelming majority of cases, the text file for (3) is in URL format: it contains a single line with the package URL and a [the standard terminating newline character](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline) (which the GitHub web interface includes automatically if editing there). In rare exceptions, the package is in a subdirectory of the GitHub repository. If that is the case, then the text file should be a JSON list with fields `package`, `url`, `subdir`, and `branch`, where `branch` must be `"*release"`. Example:
+
+```
+{
+  "package": "paws.analytics",
+  "url": "https://github.com/paws-r/paws",
+  "subdir": "cran/paws.analytics",
+  "branch": "*release"
+}
+```
 
 # How to edit or remove packages
 
-To edit or remove one or more packages, submit a pull request to edit the files in the  [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages). Your pull request will need to be briefly reviewed by an `r-releases` administrator (see below).
+To edit or remove one or more packages, submit a pull request to edit the files in the [`packages`](https://github.com/r-releases/r-releases/tree/main/packages) folder.
 
-# What do I do if my pull request is flagged for manual review?
+# Reviewing package contributions and edits
 
-Sometimes, automated reviews of pull requests may fail, or you may deliberately be trying the change a URL or remove a package. In all those cases, manual review is required if you intend to pursue the pull request as is. If your pull request is flagged for manual review, then an `r-releases` administrator will review the pull request and let you know about next steps. All we are looking for is that the package and the URL are complete and correct and that the URL attributes proper ownership. It is the responsibility of the package maintainer to implement proper testing and documentation to ensure it is working properly and remains compatible with all other packages that depend on it (see test results at <https://r-releases.r-universe.dev>.
+In the vast majority of cases, a periodic GitHub Actions workflow will automatically merge your pull request to incorporate your changes into <https://github.com/r-releases/r-releases>. However, your pull request will be flagged for manual review if:
 
-If the manual review was triggered by an error you know how to fix, please close the current pull request and submit a different one. Automated checks ignore pull requests flagged for manual review, but they do process new pull requests from the beginning.
+1. Your pull request changes or removes an existing package entry.
+2. There is something non-standard about a contributed package URL.
+3. The package entry is in JSON format.
+4. There was an error in processing your package contribution.
 
-# What happens next
+If you can change your contribution to avoid manual review, please close your pull request and submit a different one. Otherwise, an `r-releases` administrator will manually review your contribution.
 
-Periodically, a GitHub Actions workflow from <https://github.com/r-releases/r-releases.r-universe.dev> combs through the pull requests at <https://github.com/r-releases/r-releases/pulls> and automatically merges the ones that add new packages with correct-looking URLs. Pull requests that cannot be automatically merged are either closed or flagged for manual review. 
+# How the R universe is built
 
-Also periodically, another GitHub Actions workflow in <https://github.com/r-releases/r-releases.r-universe.dev> collects all the packages and URLs from the [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages) folder and builds the `packages.json` file for the R universe at <https://github.com/r-releases/r-releases.r-universe.dev>. It uses the `"branch": "*release"` field in the JSON file so that each new GitHub tag and release sends the build to the universe. Development versions are not tracked.
-
-Once your package is in `packages.json`, each new GitHub tag and release you create will publish your package to <https://r-releases.r-universe.dev> so others can install it. Please visit <https://github.com/r-releases/r-releases.r-universe.dev> and <https://r-releases.r-universe.dev> for progress and status updates on your package.
+Periodically, a GitHub Actions workflow collects all the packages and URLs from the [`packages`](https://github.com/r-releases/r-releases/tree/main/packages) folder and builds the `packages.json` file for the R universe at <https://github.com/r-releases/r-releases.r-universe.dev>. <https://r-releases.r-universe.dev> periodically refreshes to include the latest release of each package in `packages.json`.
 
 # Ownership and attribution
 

--- a/help.Rproj
+++ b/help.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This PR adds a code of conduct from `usethis::use_code_of_conduct()`. I also added the following line under "Examples of unacceptable behavior include:"

> * Maliciously attributing the wrong owner or repository in the URL of a package entry contributed to <https://github.com/r-releases/r-releases/tree/main/packages>.

In the README, I  linked to the code of conduct, explained JSON format, and generally cleaned up the wording.

@shikokuchuo, would you please review?