### PR TITLE
Align naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# r-releases
+# R-releases
 
-`r-releases` is a community-curated [R universe](https://r-releases.r-universe.dev) of R packages deployed as tags/releases on GitHub. The GitHub repository at <https://github.com/r-releases/r-releases> allows anyone to register packages with the [universe](https://r-releases.r-universe.dev). The project is still in its prototype phase, but the goal is to build a production-ready community-wide CRAN-like repository that incentivizes thorough testing and puts control in the hands of the package maintainers.
+R-releases is a community-curated [R-universe](https://r-releases.r-universe.dev) of R packages deployed as tags/releases on GitHub. The GitHub repository at <https://github.com/r-releases/r-releases> allows anyone to register packages with the [universe](https://r-releases.r-universe.dev). The project is still in its prototype phase, but the goal is to build a production-ready community-wide CRAN-like repository that incentivizes thorough testing and puts control in the hands of the package maintainers.
 
 # Disclaimer
 
-The `r-releases` project is brand new and in its prototype phase. It is not ready for widespread production usage, and policies are subject to change.
+The R-releases project is brand new and in its prototype phase. It is not ready for widespread production usage, and policies are subject to change.
 
-# How to install a package from `r-releases`
+# How to install a package from R-releases
 
-To install a package from `r-releases` (for example, `jsonlite`), open R and run:
+To install a package from R-releases (for example, `jsonlite`), open R and run:
 
 ```r
 install.packages("jsonlite", repos = "https://r-releases.r-universe.dev")
 ```
 
-If the package has dependencies in CRAN but not `r-releases`, please contribute them to `r-releases` as described below. As a temporary workaround for installation, you can include CRAN as a backup:
+If the package has dependencies in CRAN but not R-releases, please contribute them to R-releases as described below. As a temporary workaround for installation, you can include CRAN as a backup:
 
 ```r
 install.packages(
@@ -25,13 +25,13 @@ install.packages(
 
 # Continuous maintainer-driven deployment
 
-After the one-time registration process described below, each package in `r-releases` continuously deploys to `r-universe`. Every new [tag and release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) in your package's GitHub/GitLab repository automatically publishes at <https://r-releases.r-universe.dev> and becomes available to install from there. No matter how many releases you create in your own personal GitHub account, you do not need to interact with `r-releases` again unless you wish to change the link or remove the package from <https://r-releases.r-universe.dev>. In other words, you as the maintainer are in complete control. This painless maintainer-driven experience was made possible by the incredible infrastructure of [rOpenSci's R-universe system](https://ropensci.org/r-universe/) and insights from [Jeroen Ooms](https://github.com/jeroen/).
+After the one-time registration process described below, each package in R-releases continuously deploys to R-universe. Every new [tag and release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) in your package's GitHub/GitLab repository automatically publishes at <https://r-releases.r-universe.dev> and becomes available to install from there. No matter how many releases you create in your own personal GitHub account, you do not need to interact with R-releases again unless you wish to change the link or remove the package from <https://r-releases.r-universe.dev>. In other words, you as the maintainer are in complete control. This painless maintainer-driven experience was made possible by the incredible infrastructure of [rOpenSci's R-universe system](https://ropensci.org/r-universe/) and insights from [Jeroen Ooms](https://github.com/jeroen/).
 
 # Before you contribute
 
-The [code of conduct](https://github.com/r-releases/help/blob/main/CODE_OF_CONDUCT.md) governs all forms of participation in the `r-releases` project, including package contributions, issues, discussions, and the development of infrastructure. Administrators, moderators, and contributors are all subject to its terms.
+The [code of conduct](https://github.com/r-releases/help/blob/main/CODE_OF_CONDUCT.md) governs all forms of participation in the R-releases project, including package contributions, issues, discussions, and the development of infrastructure. Administrators, moderators, and contributors are all subject to its terms.
 
-# How to register your package with `r-releases`
+# How to register your package with R-releases
 
 The one-time registration process proceeds as follows.
 
@@ -57,12 +57,12 @@ In rare cases, the package may be in a subdirectory of a GitHub repo, in which c
 ```
 <br />
 
-[![r-releases status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fr-releases.r-universe.dev%2Fapi%2Fpackages%2Fmirai&query=%24.Version&label=r-releases)](https://r-releases.r-universe.dev/mirai)
+[![R-releases status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fr-releases.r-universe.dev%2Fapi%2Fpackages%2Fmirai&query=%24.Version&label=R-releases)](https://r-releases.r-universe.dev/mirai)
 
-To add a dynamic 'r-releases' badge for package readme files, like the one above, copy the following markdown snippet, replacing 'pkgNAME' with the actual package name in both places it appears:
+To add a dynamic 'R-releases' badge for package readme files, like the one above, copy the following markdown snippet, replacing 'pkgNAME' with the actual package name in both places it appears:
 
 ```md
-[![r-releases status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fr-releases.r-universe.dev%2Fapi%2Fpackages%2FpkgNAMEquery=%24.Version&label=r-releases)](https://r-releases.r-universe.dev/pkgNAME)
+[![R-releases status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fr-releases.r-universe.dev%2Fapi%2Fpackages%2FpkgNAMEquery=%24.Version&label=R-releases)](https://r-releases.r-universe.dev/pkgNAME)
 ```
 
 # How to edit or remove packages
@@ -71,11 +71,11 @@ To edit or remove one or more packages, submit a pull request to edit the files 
 
 # How pull requests are reviewed
 
-An automated process periodically scans each new pull request to https://github.com/r-releases/r-releases. Depending on the results of the automated checks, the bot automatically merges the pull request, closes it, or flags it for manual review. In the latter case, an `r-releases` moderator will manually review your pull request and contact you if there are questions. For more information on the manual review process and when it gets triggered, please visit <https://github.com/r-releases/help/blob/main/review.md>
+An automated process periodically scans each new pull request to https://github.com/r-releases/r-releases. Depending on the results of the automated checks, the bot automatically merges the pull request, closes it, or flags it for manual review. In the latter case, an R-releases moderator will manually review your pull request and contact you if there are questions. For more information on the manual review process and when it gets triggered, please visit <https://github.com/r-releases/help/blob/main/review.md>
 
-# How the R universe is built
+# How the R-releases universe is built
 
-Periodically, a GitHub Actions workflow collects all the packages and URLs from the [`packages`](https://github.com/r-releases/r-releases/tree/main/packages) folder and builds the `packages.json` file for the R universe at <https://github.com/r-releases/r-releases.r-universe.dev>. <https://r-releases.r-universe.dev> periodically refreshes to include the latest release of each package in `packages.json`.
+Periodically, a GitHub Actions workflow collects all the packages and URLs from the [`packages`](https://github.com/r-releases/r-releases/tree/main/packages) folder and builds the `packages.json` file for the universe at <https://github.com/r-releases/r-releases.r-universe.dev>. <https://r-releases.r-universe.dev> periodically refreshes to include the latest release of each package in `packages.json`.
 
 # Ownership and attribution
 

--- a/review.md
+++ b/review.md
@@ -1,6 +1,6 @@
 # Package contribution reviews
 
-As the [README](https://github.com/r-releases/help/blob/main/README.md) explains, updates to the `r-releases` package listings come from pull requests to https://github.com/r-releases/r-releases from members of the R community. In the vast majority of cases, a GitHub app automatically merges pull request. However, some pull requests need to be manually reviewed by an `r-releases` moderator. This document describes this manual review process. The goals are to:
+As the [README](https://github.com/r-releases/help/blob/main/README.md) explains, updates to the R-releases package listings come from pull requests to https://github.com/r-releases/r-releases from members of the R community. In the vast majority of cases, a GitHub app automatically merges pull request. However, some pull requests need to be manually reviewed by an R-releases moderator. This document describes this manual review process. The goals are to:
 
 1. Ensure that all pull requests are reviewed using a consistent set of standards and principles that do not vary according to moderator.
 2. Ensure these standards and principles are clear and transparent for the R community.
@@ -28,12 +28,12 @@ The pull request is automatically flagged for manual review if:
 1. The URL does not exist or is not online at the time it is checked (HTTP error trying to access it).
 1. A [release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) could not be found at the repo in the URL. (GitHub releases can be found easily, but unfortunately GitLab releases are hard to detect automatically.)
 1. The version-controlled repository name in the URL is different from the name of the file. (For example, if the file is named `gh` as the package, then the URL https://github.com/r-lib/gh-package would be flagged for manual review, but https://github.com/r-lib/gh would not.)
-1. The repository is part of the CRAN mirror at https://github.com/cran. (A fundamental goal of `r-releases` is to serve complete package dependency chains without reliance on third-party repositories as far as possible.)
+1. The repository is part of the CRAN mirror at https://github.com/cran. (A fundamental goal of R-releases is to serve complete package dependency chains without reliance on third-party repositories as far as possible.)
 1. The package is also on CRAN, and the URL in the pull request cannot be found in the `DESCRIPTION` file of the latest CRAN release.
 
 ## The manual review process
 
-If a pull request is flagged for manual review, an `r-releases` moderator will read the pull request and ask questions if necessary. Although the moderator may make optional suggestions on a case-by-case basis, package reviews must be consistent, reliable, and inclusive whenever possible. The decision to close or merge the pull request must be based exclusively on the following pre-defined list of requirements:
+If a pull request is flagged for manual review, an R-releases moderator will read the pull request and ask questions if necessary. Although the moderator may make optional suggestions on a case-by-case basis, package reviews must be consistent, reliable, and inclusive whenever possible. The decision to close or merge the pull request must be based exclusively on the following pre-defined list of requirements:
 
 1. Each contribution must comply with the [code of conduct](https://github.com/r-releases/help/blob/main/CODE_OF_CONDUCT.md). Examples of prohibited content include profanity, malicious behavior, security risks, copyright violations, and other conduct which could reasonably be considered inappropriate in a professional setting. All this applies to the package, the URL, any other metadata in the contribution, and the contents of the package itself. 
 1. Each contributed URL must point to an existing GitHub or GitLab repository.


### PR DESCRIPTION
This PR replaces `r-releases` with R-releases and `r-universe` with R-universe. It is easier to write about these things in prose if the first letter is capitalized, and R-universe is written as "R-universe" where it appears in the rOpenSci posts.