### PR TITLE
Gitlab-relelated enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ R-releases aims to facilitate production as well. In addition to its encapsulate
 To install a package from R-releases (for example, `jsonlite`), open R and run:
 
 ```r
-install.packages("jsonlite", repos = "https://r-releases.r-universe.dev")
-```
-
-If the package has dependencies in CRAN but not R-releases, please contribute them to R-releases as described below. As a temporary workaround for installation, you can include CRAN as a backup:
-
-```r
 install.packages(
   "jsonlite",
   repos = c("https://r-releases.r-universe.dev", "https://cloud.r-project.org")
@@ -46,7 +40,7 @@ The [code of conduct](https://github.com/r-releases/help/blob/main/CODE_OF_CONDU
 
 The one-time registration process proceeds as follows.
 
-1. Ensure that the package source code exists in a public [GitHub](https://github.com) (or [GitLab](https://gitlab.com)) repository with the `DESCRIPTION` file at the root of the project. Example: <https://github.com/r-lib/gh>.
+1. Ensure that the package source code exists in a public [GitHub](https://github.com) or [GitLab](https://gitlab.com) repository with the `DESCRIPTION` file at the root of the project. Example: <https://github.com/r-lib/gh>.
 2. Ensure that the package has a [release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for the latest production version of your package. Example: <https://github.com/r-lib/gh/releases/tag/v1.4.0>.
 3. Open a [GitHub pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to <https://github.com/r-releases/r-releases> to contribute one or more text files to the [`packages` folder](https://github.com/r-releases/r-releases/tree/main/packages) with R package listings.
 

--- a/review.md
+++ b/review.md
@@ -1,6 +1,6 @@
 # Package contribution reviews
 
-As the [README](https://github.com/r-releases/help/blob/main/README.md) explains, updates to the R-releases package listings come from pull requests to https://github.com/r-releases/r-releases from members of the R community. In the vast majority of cases, a GitHub app automatically merges pull request. However, some pull requests need to be manually reviewed by an R-releases moderator. This document describes this manual review process. The goals are to:
+As the [README](https://github.com/r-releases/help/blob/main/README.md) explains, updates to the R-releases package listings come from pull requests to https://github.com/r-releases/r-releases from members of the R community. In the vast majority of cases, a GitHub app automatically merges the pull request. However, some pull requests need to be manually reviewed by an R-releases moderator. This document describes this manual review process. The goals are to:
 
 1. Ensure that all pull requests are reviewed using a consistent set of standards and principles that do not vary according to moderator.
 2. Ensure these standards and principles are clear and transparent for the R community.
@@ -26,7 +26,7 @@ The pull request is automatically flagged for manual review if:
 1. The domain of the URL is anything other than github.com or gitlab.com.
 1. The URL points to an organization or user such as https://github.com/r-lib rather than a repository such as https://github.com/r-lib/gh.
 1. The URL does not exist or is not online at the time it is checked (HTTP error trying to access it).
-1. A [release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) could not be found at the repo in the URL. (GitHub releases can be found easily, but unfortunately GitLab releases are hard to detect automatically.)
+1. A [release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) could not be found at the repo in the URL.
 1. The version-controlled repository name in the URL is different from the name of the file. (For example, if the file is named `gh` as the package, then the URL https://github.com/r-lib/gh-package would be flagged for manual review, but https://github.com/r-lib/gh would not.)
 1. The repository is part of the CRAN mirror at https://github.com/cran. (A fundamental goal of R-releases is to serve complete package dependency chains without reliance on third-party repositories as far as possible.)
 1. The package is also on CRAN, and the URL in the pull request cannot be found in the `DESCRIPTION` file of the latest CRAN release.
@@ -39,7 +39,7 @@ If a pull request is flagged for manual review, an R-releases moderator will rea
 1. Each contributed URL must point to an existing GitHub or GitLab repository.
 1. Each text file must apply to only one package.
 1. The text file name must be the name of the package.
-1. For JSON listings, the `"branch"` field must be `"*release"`, the `"subdirectory"` field must be supplied and exist, the `"url"` field must exist and be correct, and the `"package"` field must agree with the name of the text file.
+1. For JSON listings, the `"branch"` field must be `"*release"` (except in specific predetermined cases such as packages in https://github.com/cran), the `"subdirectory"` field must be supplied and exist, the `"url"` field must exist and be correct, and the `"package"` field must agree with the name of the text file.
 1. The package name, URL, and all other metadata must be complete and correct.
 1. The URL must be the true/official location of the source code or a faithful mirror of the true location. The package maintainers have the authority to choose the URL. Unofficial or unsupported forks should not be included. The moderator must use discretion on a case-by-case basis because sometimes a fork becomes the true version (e.g. if the original maintainer abandons a package and becomes unreachable indefinitely).
 1. The URL must have a release on GitHub or GitLab so R-universe can process the package without error. As a last resort, if the maintainer does not provide their own releases, a repository from the CRAN mirror at https://github.com/cran may be registered.


### PR DESCRIPTION
This PR makes it clear that GitLab is a first-class citizen. Though it does require us to take care of https://github.com/r-releases/r.releases.internals/pull/12 first.